### PR TITLE
Fix FFmpeg finalization timeout for long exports

### DIFF
--- a/src-tauri/ovrley_core/src/encode/pipeline/lifecycle.rs
+++ b/src-tauri/ovrley_core/src/encode/pipeline/lifecycle.rs
@@ -71,7 +71,7 @@ impl PipelineShutdown {
 }
 
 const WRITER_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
-const FFMPEG_FINALIZE_TIMEOUT: Duration = Duration::from_secs(30);
+const FFMPEG_FINALIZE_TIMEOUT: Duration = Duration::from_secs(600);
 const FFMPEG_TERMINATE_TIMEOUT: Duration = Duration::from_secs(2);
 const SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(25);
 


### PR DESCRIPTION
## Problem

Long video exports can finish rendering all frames successfully, but FFmpeg
may need more than 30 seconds to finalize the output file.

When finalization exceeds the fixed 30-second timeout, OVRLEY terminates
FFmpeg and removes the output, even though rendering reached 100%.

I reproduced this with a GoPro 4K60 project:

- the video was approximately 37 minutes
- approximately 132,000 frames
- H.264 full-video export using NVIDIA hardware encoding
- rendering reached 100%
- FFmpeg was terminated during finalization
- no completed output file was preserved

## Change

Increase `FFMPEG_FINALIZE_TIMEOUT` from 30 seconds to 600 seconds.

The timeout remains bounded, so an actually stalled FFmpeg process can still
be terminated, while large exports have enough time to complete finalization.

## Validation

The issue was originally reproduced on OVRLEY 2.21.6.

The change was then applied and built against the current main branch after
the 2.21.7 release.

Tests performed on Windows 11:

- Transparent ProRes export completed successfully.
- Full-video H.264 export completed successfully.
- Full-video finalization clearly took longer than 30 seconds, approximately
  90 seconds.
- The resulting output file was preserved and plays correctly.
- The same project previously failed under the original 30-second timeout.