### PR TITLE
Build and rendering improvements

### DIFF
--- a/scripts/install-ffmpeg.mjs
+++ b/scripts/install-ffmpeg.mjs
@@ -6,11 +6,17 @@ import { basename, dirname, join, resolve } from "node:path";
 import { spawn, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
-const PINNED_BTBN_FFMPEG_BUILD = "N-125608-g150f7d15df";
+// Pin to the last monthly BtbN autobuild.
+// Daily autobuilds are periodically removed and may return HTTP 404.
+const PINNED_BTBN_AUTOBUILD = "autobuild-2026-07-31-14-10";
+const PINNED_BTBN_FFMPEG_BUILD = "N-125875-g5d4d3bdc61";
+const BTBN_BASE =
+  `https://github.com/BtbN/FFmpeg-Builds/releases/download/${PINNED_BTBN_AUTOBUILD}`;
 const PINNED_WINDOWS_FFMPEG_ARCHIVE =
-  "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-07-14-13-19/ffmpeg-N-125608-g150f7d15df-win64-gpl-shared.zip";
+  `${BTBN_BASE}/ffmpeg-${PINNED_BTBN_FFMPEG_BUILD}-win64-gpl-shared.zip`;
 const PINNED_LINUX_FFMPEG_ARCHIVE =
-  "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-07-14-13-19/ffmpeg-N-125608-g150f7d15df-linux64-gpl-shared.tar.xz";
+  `${BTBN_BASE}/ffmpeg-${PINNED_BTBN_FFMPEG_BUILD}-linux64-gpl-shared.tar.xz`;
+
 const PINNED_DARWIN_FFMPEG_VERSION = "8.1.2";
 const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const installDir = join(rootDir, "vendor", "ffmpeg");

--- a/src-tauri/ovrley_core/src/encode/pipeline/frame_pool.rs
+++ b/src-tauri/ovrley_core/src/encode/pipeline/frame_pool.rs
@@ -12,7 +12,16 @@ use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
 
 const MAX_PARALLEL_FRAME_BUFFERS: usize = 5;
 pub const MAX_FRAME_WORKERS: usize = MAX_PARALLEL_FRAME_BUFFERS - 1;
-const PARALLEL_FRAME_MEMORY_CEILING_BYTES: usize = 192 * 1024 * 1024;
+
+/// Upper limit for RGBA frame pool memory.
+///
+/// Increased from 192 MiB to 512 MiB to support high-resolution sources,
+/// including DJI Action 4 portrait footage (2880×3840), while maintaining
+/// a conservative upper memory bound.
+///
+/// This allows the default 4-worker pipeline to allocate enough RGBA
+/// frame buffers without exhausting the frame pool.
+const PARALLEL_FRAME_MEMORY_CEILING_BYTES: usize = 512 * 1024 * 1024;
 
 /// Diagnoses the canonical frame-worker count for one codec profile and render.
 pub fn diagnose_frame_worker_count(


### PR DESCRIPTION
## Summary

This pull request includes two independent improvements:

- Update the pinned BtbN FFmpeg monthly autobuild to improve build reliability.
- Increase the RGBA frame pool memory ceiling from 192 MiB to 512 MiB to improve compatibility with high-resolution video sources.

## Changes

### Build

- Pin the latest monthly BtbN FFmpeg autobuild.
- Avoid failures caused by expired daily autobuilds.

### Rendering

- Increase `PARALLEL_FRAME_MEMORY_CEILING_BYTES`
  - 192 MiB → 512 MiB
- Improve support for high-resolution footage, including DJI Action 4 portrait videos (2880×3840).

## Notes

This PR does **not** introduce any functional changes to activity import or overlay rendering logic.