### PR TITLE
feat(csv): import vehicle telemetry into canonical metrics

### DIFF
--- a/src-tauri/ovrley_core/src/activity/csv/columns.rs
+++ b/src-tauri/ovrley_core/src/activity/csv/columns.rs
@@ -267,6 +267,8 @@ pub(super) fn build_activity_columns(
         heading: preserve_heading_gaps,
     };
     let (rpm, _) = series(Metric::Rpm);
+    let (power, _) = series(Metric::Power);
+    let (torque, _) = series(Metric::Torque);
     let (throttle_position, _) = series(Metric::ThrottlePosition);
     let (brake_position, _) = series(Metric::BrakePosition);
     let (source_lap_number, _) = series(Metric::LapNumber);
@@ -373,13 +375,13 @@ pub(super) fn build_activity_columns(
         include_original_sample_count_metadata: false,
         heartrate: empty(),
         cadence: empty(),
-        power: empty(),
+        power,
         temperature: empty(),
         calories: empty(),
         gradient: empty(),
         pace: empty(),
         vertical_speed: empty(),
-        torque: empty(),
+        torque,
         stroke_rate: empty(),
         stride_length: empty(),
         vertical_oscillation: empty(),

--- a/src-tauri/ovrley_core/src/activity/csv/metrics.rs
+++ b/src-tauri/ovrley_core/src/activity/csv/metrics.rs
@@ -141,8 +141,31 @@ fn candidate_columns<'a>(
                 && column_unit(column, units_row).is_some()
         })
         .collect::<Vec<_>>();
-    candidates.sort_by_key(|column| (column.priority, column.index));
+    candidates.sort_by_key(|column| {
+        (
+            power_unit_priority(metric, column_unit(column, units_row)),
+            column.priority,
+            column.index,
+        )
+    });
     candidates
+}
+
+/// Prefers explicit watt power sources over kilowatts and metric horsepower.
+///
+/// Each source remains a single selected column; this only ranks otherwise
+/// compatible alternatives for the same canonical metric.
+fn power_unit_priority(metric: Metric, unit: Option<Unit>) -> u8 {
+    if metric != Metric::Power {
+        return 0;
+    }
+
+    match unit {
+        Some(Unit::Watts) => 0,
+        Some(Unit::Kilowatts) => 1,
+        Some(Unit::MetricHorsepower) => 2,
+        _ => u8::MAX,
+    }
 }
 
 /// Parses, converts, and validates one metric observation.
@@ -215,7 +238,14 @@ fn validate(metric: Metric, value: f64) -> Option<f64> {
     match metric {
         Metric::Latitude if !(-90.0..=90.0).contains(&value) => None,
         Metric::Longitude if !(-180.0..=180.0).contains(&value) => None,
-        Metric::Speed | Metric::Distance | Metric::DistanceToHome | Metric::Rpm if value < 0.0 => {
+        Metric::Speed
+        | Metric::Distance
+        | Metric::DistanceToHome
+        | Metric::Rpm
+        | Metric::Power
+        | Metric::Torque
+            if value < 0.0 =>
+        {
             None
         }
         Metric::ThrottlePosition | Metric::BrakePosition if !(0.0..=100.0).contains(&value) => None,

--- a/src-tauri/ovrley_core/src/activity/csv/mod.rs
+++ b/src-tauri/ovrley_core/src/activity/csv/mod.rs
@@ -60,6 +60,10 @@ enum Metric {
     GForceZ,
     /// Engine speed in revolutions per minute.
     Rpm,
+    /// Mechanical power in watts.
+    Power,
+    /// Mechanical torque in newton metres.
+    Torque,
     /// Throttle position as a percentage from zero to one hundred.
     ThrottlePosition,
     /// Brake position as a percentage from zero to one hundred.

--- a/src-tauri/ovrley_core/src/activity/csv/parser.rs
+++ b/src-tauri/ovrley_core/src/activity/csv/parser.rs
@@ -293,6 +293,8 @@ fn parse_header(index: usize, value: &str) -> Option<HeaderColumn> {
             Some(AccelerationKind::Semantic),
         ),
         "rpm" | "engine rpm" => (Metric::Rpm, SourcePriority::Direct, None, None, None),
+        "power" | "estimated power" => (Metric::Power, SourcePriority::Direct, None, None, None),
+        "torque" | "estimated torque" => (Metric::Torque, SourcePriority::Direct, None, None, None),
         "accelerator position" | "accelerator pedal position" => (
             Metric::ThrottlePosition,
             SourcePriority::Pedal,
@@ -300,7 +302,7 @@ fn parse_header(index: usize, value: &str) -> Option<HeaderColumn> {
             Some(ControlKind::Percentage),
             None,
         ),
-        "throttle position" | "throttlepos" => (
+        "throttle position" | "relative throttle position" | "throttlepos" => (
             Metric::ThrottlePosition,
             SourcePriority::Direct,
             None,
@@ -350,8 +352,10 @@ fn parse_header(index: usize, value: &str) -> Option<HeaderColumn> {
             None,
         ),
         "lean angle" | "leanangle" => (Metric::LeanAngle, SourcePriority::Direct, None, None, None),
-        "lap" | "lap #" | "lap number" => (Metric::LapNumber, SourcePriority::Direct, None, None, None),
-        "gear" => (
+        "lap" | "lap #" | "lap number" => {
+            (Metric::LapNumber, SourcePriority::Direct, None, None, None)
+        }
+        "gear" | "gear position" | "estimated gear" => (
             Metric::GearPosition,
             SourcePriority::Direct,
             None,
@@ -370,7 +374,9 @@ fn parse_header(index: usize, value: &str) -> Option<HeaderColumn> {
     let mut declared_unit = declared_unit;
     if metric == Metric::Timestamp
         && annotation.as_deref().is_some_and(|ann| {
-            ann.eq_ignore_ascii_case("utc") || ann.eq_ignore_ascii_case("gmt") || ann.eq_ignore_ascii_case("z")
+            ann.eq_ignore_ascii_case("utc")
+                || ann.eq_ignore_ascii_case("gmt")
+                || ann.eq_ignore_ascii_case("z")
         })
     {
         declared_unit = DeclaredUnit::Absent;

--- a/src-tauri/ovrley_core/src/activity/csv/units.rs
+++ b/src-tauri/ovrley_core/src/activity/csv/units.rs
@@ -37,6 +37,14 @@ pub(super) enum Unit {
     Percent,
     /// Revolutions per minute.
     RevolutionsPerMinute,
+    /// Mechanical power in watts.
+    Watts,
+    /// Mechanical power in kilowatts.
+    Kilowatts,
+    /// Metric horsepower (CV).
+    MetricHorsepower,
+    /// Mechanical torque in newton metres.
+    NewtonMetres,
     /// Unscaled numeric value.
     Raw,
 }
@@ -89,6 +97,11 @@ pub(super) fn parse_declared_unit(value: &str) -> DeclaredUnit {
         "g" => Unit::G,
         "%" | "percent" | "percentage" => Unit::Percent,
         "rpm" => Unit::RevolutionsPerMinute,
+        "w" | "watt" | "watts" => Unit::Watts,
+        "kw" | "kilowatt" | "kilowatts" => Unit::Kilowatts,
+        "cv" => Unit::MetricHorsepower,
+        "nm" | "n·m" | "n*m" | "n-m" | "newton metre" | "newton metres" | "newton meter"
+        | "newton meters" => Unit::NewtonMetres,
         "#" | "raw" => Unit::Raw,
         _ => return DeclaredUnit::Unsupported(UnitDimension::Unknown),
     };
@@ -183,10 +196,14 @@ pub(super) fn compatible(metric: Metric, unit: Unit) -> bool {
             matches!(unit, Unit::G)
         }
         Metric::Rpm => matches!(unit, Unit::RevolutionsPerMinute),
+        Metric::Power => matches!(unit, Unit::Watts | Unit::Kilowatts | Unit::MetricHorsepower),
+        Metric::Torque => matches!(unit, Unit::NewtonMetres),
         Metric::ThrottlePosition | Metric::BrakePosition => matches!(unit, Unit::Percent),
         Metric::LeanAngle => matches!(unit, Unit::Degrees),
         Metric::GearPosition => matches!(unit, Unit::Raw),
-        Metric::CompanionDate | Metric::GpsCoordinate | Metric::LapNumber => matches!(unit, Unit::Raw),
+        Metric::CompanionDate | Metric::GpsCoordinate | Metric::LapNumber => {
+            matches!(unit, Unit::Raw)
+        }
     }
 }
 
@@ -197,6 +214,8 @@ pub(super) fn convert(value: f64, unit: Unit) -> f64 {
         Unit::MilesPerHour => value * 0.44704,
         Unit::Kilometres => value * 1000.0,
         Unit::Feet => value * 0.3048,
+        Unit::Kilowatts => value * 1000.0,
+        Unit::MetricHorsepower => value * 735.49875,
         Unit::Seconds
         | Unit::DecimalDegrees
         | Unit::MetresPerSecond
@@ -205,6 +224,8 @@ pub(super) fn convert(value: f64, unit: Unit) -> f64 {
         | Unit::G
         | Unit::Percent
         | Unit::RevolutionsPerMinute
+        | Unit::Watts
+        | Unit::NewtonMetres
         | Unit::Raw => value,
     }
 }
@@ -222,6 +243,8 @@ fn default_unit(metric: Metric) -> Unit {
         Metric::Heading => Unit::Degrees,
         Metric::GForce | Metric::GForceX | Metric::GForceY | Metric::GForceZ => Unit::G,
         Metric::Rpm => Unit::RevolutionsPerMinute,
+        Metric::Power => Unit::Watts,
+        Metric::Torque => Unit::NewtonMetres,
         Metric::ThrottlePosition | Metric::BrakePosition => Unit::Percent,
         Metric::LeanAngle => Unit::Degrees,
         Metric::GearPosition => Unit::Raw,

--- a/src-tauri/ovrley_core/tests/csv_activity.rs
+++ b/src-tauri/ovrley_core/tests/csv_activity.rs
@@ -777,6 +777,47 @@ fn vehicle_sources_and_accelerator_pedals_win_and_controls_normalize_by_column()
 }
 
 #[test]
+fn enriched_vehicle_columns_feed_existing_canonical_metrics() {
+    let csv = "Time,Estimated Torque (Nm),Estimated Power (kW),Estimated Power (CV),Estimated Gear,RPM,Throttle Position (%)\n\
+0,35.5,10.0,20.0,4,3214,27.5\n\
+1,,,,5,,\n\
+2,,,,,,\n";
+
+    let activity = parse_csv_activity_reader(Cursor::new(csv), "enriched.csv")
+        .unwrap()
+        .parsed_activity;
+
+    assert_eq!(activity.torque, vec![Some(35.5), None, None]);
+    assert_eq!(activity.power, vec![Some(10_000.0), None, None]);
+    assert_eq!(
+        activity.gear_position,
+        vec![Some("4".to_string()), Some("5".to_string()), None]
+    );
+    assert_eq!(activity.rpm, vec![Some(3214.0), None, None]);
+    assert_eq!(activity.throttle_position, vec![Some(27.5), None, None]);
+
+    let cv_csv = "Time,Estimated Power (CV)\n0,20.0\n1,\n";
+    let cv_activity = parse_csv_activity_reader(Cursor::new(cv_csv), "cv.csv")
+        .unwrap()
+        .parsed_activity;
+    assert_close(cv_activity.power[0], 14_709.975);
+    assert_eq!(cv_activity.power[1], None);
+}
+
+#[test]
+fn explicit_watts_outrank_kw_and_cv_power_sources() {
+    let csv = "Time,Estimated Power (CV),Power (kW),Power (W)\n\
+0,20,10,12345\n\
+1,21,11,23456\n";
+
+    let activity = parse_csv_activity_reader(Cursor::new(csv), "power-priority.csv")
+        .unwrap()
+        .parsed_activity;
+
+    assert_eq!(activity.power, vec![Some(12_345.0), Some(23_456.0)]);
+}
+
+#[test]
 fn acceleration_axes_preserve_signs_and_scalar_uses_the_agreed_precedence() {
     let semantic_csv =
         "Time,Lateral acceleration (G),Longitudinal acceleration (G),Lean angle (deg)\n\


### PR DESCRIPTION
## Summary

Extends the generic CSV importer to recognize vehicle telemetry columns for power, torque, and gear while reusing the existing canonical `power`, `torque`, and `gear_position` channels. No new metrics, schema changes, or widgets are introduced.

- Supports common aliases including `Estimated Torque (Nm)`, `Estimated Power (kW/CV)`, `Power (W/kW/CV)`, `Estimated Gear` / `Gear` / `Gear Position`, and `Relative Throttle Position`.
- Converts kW and metric horsepower (CV) to canonical watts.
- Selects power sources with precedence: W > kW > CV.
- Preserves missing values; existing canonical widgets work without special bindings.

## Validation

- `cargo check --manifest-path src-tauri/ovrley_core/Cargo.toml`
- Focused CSV tests
- GitHub Actions Windows portable build
- Manual Windows validation with a real RaceChrono enriched CSV: Power, Torque, Gear Position, RPM, Speed, and Throttle